### PR TITLE
Add minor clarifying details about function output in help documentation for ecospat.plot.overlap.test

### DIFF
--- a/ecospat/man/ecospat.plot.overlap.test.Rd
+++ b/ecospat/man/ecospat.plot.overlap.test.Rd
@@ -4,7 +4,7 @@
 
 \title{Plot Overlap Test}
 
-\description{Plot a histogram of observed and randomly simulated overlaps, with p-values of equivalency or similarity tests.}
+\description{Plot a histogram of randomly simulated overlap values (grey bars) and the observed overlap value (red vertical line with a diamond marker), with p-values of equivalency or similarity tests.}
 
 \usage{ecospat.plot.overlap.test (x, type, title)}
 


### PR DESCRIPTION
I added a couple of minor details to the `ecospat.plot.overlap.test.Rd` - namely that the histogram produced is for the simulated overlap values and that the red vertical line with diamond marker is the observed overlap value. Thanks so much again for your all's incredible work on this package!!