### PR TITLE
Fix typos in niche equivalency and similarity test functions

### DIFF
--- a/ecospat/R/ecospat.nicheoverlap.R
+++ b/ecospat/R/ecospat.nicheoverlap.R
@@ -317,7 +317,7 @@ ecospat.niche.similarity.test <- function(z1, z2, rep, intersection = 0, rand.ty
     stop("Please choose an alternative hypothesis (higher,lower or different) for the expansion")
   }
   if (isFALSE(stability.alternative %in% c("higher","lower","different"))){
-    stop("Please choose an alternative hypothesis (higher,lower or difefrent) for the stability")
+    stop("Please choose an alternative hypothesis (higher,lower or different) for the stability")
   }
   if (isFALSE(unfilling.alternative %in% c("higher","lower","different"))){
     stop("Please choose an alternative hypothesis (higher,lower or different) for the unfilling")

--- a/ecospat/R/ecospat.nicheoverlap.R
+++ b/ecospat/R/ecospat.nicheoverlap.R
@@ -126,16 +126,16 @@ ecospat.niche.equivalency.test <- function(z1, z2, rep,intersection = 0,
                                            unfilling.alternative = "lower",
                                            ncores=1) {
   if (isFALSE(overlap.alternative %in% c("higher","lower","different"))){
-    stop("Please choose an alternative hypothesis (higher,lower or diffrent) for the overlap")
+    stop("Please choose an alternative hypothesis (higher,lower or different) for the overlap")
   }
   if (isFALSE(expansion.alternative %in% c("higher","lower","different"))){
-    stop("Please choose an alternative hypothesis (higher,lower or diffrent) for the expansion")
+    stop("Please choose an alternative hypothesis (higher,lower or different) for the expansion")
   }
   if (isFALSE(stability.alternative %in% c("higher","lower","different"))){
-    stop("Please choose an alternative hypothesis (higher,lower or diffrent) for the stability")
+    stop("Please choose an alternative hypothesis (higher,lower or different) for the stability")
   }
-  if (isFALSE(stability.alternative %in% c("higher","lower","different"))){
-    stop("Please choose an alternative hypothesis (higher,lower or diffrent) for the unfilling")
+  if (isFALSE(unfilling.alternative %in% c("higher","lower","different"))){
+    stop("Please choose an alternative hypothesis (higher,lower or different) for the unfilling")
   }
   R <- length(z1$x)
   l <- list()
@@ -319,7 +319,7 @@ ecospat.niche.similarity.test <- function(z1, z2, rep, intersection = 0, rand.ty
   if (isFALSE(stability.alternative %in% c("higher","lower","different"))){
     stop("Please choose an alternative hypothesis (higher,lower or difefrent) for the stability")
   }
-  if (isFALSE(stability.alternative %in% c("higher","lower","different"))){
+  if (isFALSE(unfilling.alternative %in% c("higher","lower","different"))){
     stop("Please choose an alternative hypothesis (higher,lower or different) for the unfilling")
   }
   


### PR DESCRIPTION
While exploring the niche equivalency and similarity test functions (`ecospat.niche.equivalency.test()` and `ecospat.niche.similarity.test()`), I found and corrected a few minor typos in those functions in `ecospat.nicheoverlap.R`. Thank you for maintaining such a great ecological modeling resource - I've benefited a lot from using it!